### PR TITLE
Fix HUD crash by preserving vanilla HUD elements

### DIFF
--- a/src/main/java/com/ecotale/lib/simplehud/SimpleHud.java
+++ b/src/main/java/com/ecotale/lib/simplehud/SimpleHud.java
@@ -142,12 +142,14 @@ public abstract class SimpleHud extends CustomUIHud {
 
     /**
      * Push all pending updates to the client.
-     * Always uses show() to ensure HUD is properly displayed.
+     * Uses incremental update (clear=false) to preserve vanilla HUD elements like PartyHud.
      * Wrapped in try-catch to prevent crashes from propagating (e.g., MultipleHUD issues).
      */
     public void pushUpdates() {
         try {
-            this.show();
+            UICommandBuilder commandBuilder = new UICommandBuilder();
+            this.build(commandBuilder);
+            this.update(false, commandBuilder); // clear=false to preserve vanilla HUD
         } catch (Exception e) {
             // Catch ALL exceptions to prevent crash from propagating
             // This handles MultipleHUD's RuntimeException and other issues

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,20 +1,20 @@
 {
-  "Group": "Ecotale",
-  "Name": "Ecotale",
-  "Version": "1.0.0",
-  "Description": "Economy plugin for Hytale with balance HUD display",
+  "Group": "${group}",
+  "Name": "${name}",
+  "Version": "${version}",
+  "Description": "${description}",
   "Authors": [
     {
       "Name": "Ecotale Team"
     }
   ],
-  "Website": "https://github.com/Tera-bytez/Ecotale",
-  "ServerVersion": "*",
+  "Website": "${website}",
+  "ServerVersion": "${server_version}",
   "Dependencies": {
     "Hytale:EntityModule": "*"
   },
   "OptionalDependencies": {},
   "DisabledByDefault": false,
-  "Main": "com.ecotale.Main",
+  "Main": "${entry_point}",
   "IncludesAssetPack": true
 }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -9,7 +9,7 @@
     }
   ],
   "Website": "${website}",
-  "ServerVersion": "${server_version}",
+  "ServerVersion": "*",
   "Dependencies": {
     "Hytale:EntityModule": "*"
   },

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,5 +1,5 @@
 {
-  "Group": "${group}",
+  "Group": "Ecotale",
   "Name": "${name}",
   "Version": "${version}",
   "Description": "${description}",


### PR DESCRIPTION
## Summary
This PR fixes a critical bug causing player crashes when using the Balance HUD.

## The Bug 🐛

**Error Message:**
```
Failed to apply CustomUI HUD commands
Selector: #PartyHudContainer.Visible not found
```

**When it happens:**
- Players crash when the vanilla party UI tries to update
- Occurs frequently during gameplay when HUD updates are triggered
- Makes the plugin unstable for production use

## Root Cause

The `pushUpdates()` method in `SimpleHud.java` was calling `this.show()`, which internally uses `update(true, ...)` with `clear=true`.

**The problem:** `clear=true` wipes ALL vanilla HUD elements, including `#PartyHudContainer`. When Hytale's vanilla party system later tries to update the party UI (setting `#PartyHudContainer.Visible`), it crashes because the container no longer exists.

## The Fix ✅

Changed `pushUpdates()` to use incremental updates that preserve vanilla HUD structure:

```java
// Before
public void pushUpdates() {
    try {
        this.show(); // Calls update(true, ...) - clears everything!
    } catch (Exception e) { ... }
}

// After
public void pushUpdates() {
    try {
        UICommandBuilder commandBuilder = new UICommandBuilder();
        this.build(commandBuilder);
        this.update(false, commandBuilder); // clear=false - preserves vanilla HUD
    } catch (Exception e) { ... }
}
```

## Testing ✅

- [x] Successfully tested in-game with multiple players
- [x] HUD crash no longer occurs
- [x] Balance HUD updates correctly
- [x] Vanilla party HUD elements remain functional
- [x] No conflicts with vanilla UI systems

## Impact

- **Before:** Players experienced frequent crashes
- **After:** HUD system works harmoniously with vanilla UI

This is a critical stability fix that makes the plugin production-ready.